### PR TITLE
Addition of VanHove in ddMd and modifications in ddMd/diagnostics

### DIFF
--- a/src/ddMd/analyzers/OutputEnergy.cpp
+++ b/src/ddMd/analyzers/OutputEnergy.cpp
@@ -19,6 +19,9 @@
 #ifdef INTER_DIHEDRAL
 #include <ddMd/potentials/dihedral/DihedralPotential.h>
 #endif
+#ifdef INTER_EXTERNAL
+#include <ddMd/potentials/external/ExternalPotential.h>
+#endif
 #include <util/format/Int.h>
 #include <util/format/Dbl.h>
 #include <util/mpi/MpiLoader.h>
@@ -71,7 +74,6 @@ namespace DdMd
       saveOutputFileName(ar);
       ar << nSample_;
    }
-
   
    /*
    * Reset nSample.
@@ -115,6 +117,13 @@ namespace DdMd
                double dihedral  = sys.dihedralPotential().energy();
                potential += dihedral;
                Log::file() << Dbl(dihedral, 15);
+            }
+            #endif
+            #ifdef INTER_EXTERNAL
+            if (sys.hasExternal()) {
+               double external = sys.externalPotential().energy();
+               potential += external;
+               Log::file() << Dbl(external, 15);
             }
             #endif
             Log::file() << Dbl(kinetic + potential, 20)

--- a/src/ddMd/analyzers/StructureFactor.h
+++ b/src/ddMd/analyzers/StructureFactor.h
@@ -177,21 +177,6 @@ namespace DdMd
       */
       DMatrix<double>  modes_;
 
-      /**
-      * Array of vector of maximum structure factor values. 
-      */
-      DArray< std::vector<double> > maximumValue_;
-
-      /**
-      * Array of vector of Miller index IntVector with maximum S(q).
-      */
-      DArray< std::vector<IntVector> > maximumWaveIntVector_;
-
-      /**
-      * Array of vector of magnitudes of waveVector with maximum S(q).
-      */
-      DArray< std::vector<double> > maximumQ_;
-
       /// Number of wavevectors.
       int  nWave_;
 
@@ -212,6 +197,8 @@ namespace DdMd
       /// Has readParam been called?
       bool isInitialized_;
 
+     /// Is this the first step?
+     bool isFirstStep_;
    };
 
 }

--- a/src/ddMd/analyzers/StructureFactorGrid.h
+++ b/src/ddMd/analyzers/StructureFactorGrid.h
@@ -99,6 +99,18 @@ namespace DdMd
       virtual void save(Serializable::OArchive &ar);
   
       /**
+      * Set up before a simulation.
+      */
+      virtual void clear();
+
+      /**
+      * Add particles to StructureFactor accumulators.
+      *
+      * \param iStep step counter
+      */
+      virtual void sample(long iStep);
+
+      /**
       * Output structure factors, averaged over stars.
       */
       virtual void output();
@@ -120,6 +132,11 @@ namespace DdMd
       /// Lattice system used to create stars.
       LatticeSystem   lattice_;
 
+      /// Has readParam been called?
+      bool    isInitialized_;
+     
+      /// Log file
+      std::ofstream logFile_;
    };
 
 }

--- a/src/ddMd/analyzers/VanHove.cpp
+++ b/src/ddMd/analyzers/VanHove.cpp
@@ -1,0 +1,261 @@
+#ifndef DDMD_VAN_HOVE_CPP
+#define DDMD_VAN_HOVE_CPP
+
+/*
+* Simpatico - Simulation Package for Polymeric and Molecular Liquids
+*
+* Copyright 2010 - 2012, David Morse (morse012@umn.edu)
+* Distributed under the terms of the GNU General Public License.
+*/
+
+#include "VanHove.h"
+#include <ddMd/simulation/Simulation.h>
+#include <ddMd/simulation/SimulationAccess.h>
+#include <ddMd/storage/AtomStorage.h>
+#include <ddMd/storage/AtomIterator.h>
+#include <ddMd/communicate/Exchanger.h>
+#include <util/boundary/Boundary.h>
+#include <util/math/Constants.h>
+#include <util/space/Dimension.h>
+#include <util/space/IntVector.h>
+#include <util/misc/ioUtil.h>
+#include <util/mpi/MpiLoader.h>
+#include <util/misc/FileMaster.h>
+#include <util/archives/Serializable_includes.h>
+#include <util/misc/ioUtil.h>
+#include <util/format/Int.h>
+#include <util/format/Dbl.h>
+
+namespace DdMd
+{
+
+   using namespace Util;
+
+   /*
+   * Constructor.
+   */
+   VanHove::VanHove(Simulation& simulation) 
+    : Analyzer(simulation),
+      isInitialized_(false)
+   {  setClassName("VanHove"); }
+
+   /*
+   * Destructor
+   */
+   VanHove::~VanHove() 
+   {}
+
+   /*
+   * Read parameters from file, and allocate memory.
+   */
+   void VanHove::readParameters(std::istream& in) 
+   {
+      readInterval(in);
+      readOutputFileName(in);
+
+      nAtomType_ = simulation().nAtomType();
+      atomTypeCoeffs_.allocate(nAtomType_);
+      readDArray<double>(in, "atomTypeCoeffs", atomTypeCoeffs_, nAtomType_);
+
+      read<int>(in, "nBuffer", nBuffer_);
+      read<int>(in, "nWave", nWave_);
+      waveIntVectors_.allocate(nWave_);
+      waveVectors_.allocate(nWave_);
+      fourierModes_.allocate(nWave_);
+      totalFourierModes_.allocate(nWave_);
+
+      if (simulation().domain().isMaster()) {
+         accumulators_.allocate(nWave_);
+         for (int i = 0; i < nWave_; ++i) {
+            accumulators_[i].setParam(nBuffer_);
+         }
+      }
+
+      readDArray<IntVector>(in, "waveIntVectors", waveIntVectors_, nWave_);
+      isInitialized_ = true;
+   }
+
+   /*
+   * Load state from an archive.
+   */
+   void VanHove::loadParameters(Serializable::IArchive& ar)
+   {  
+      nAtomType_ = simulation().nAtomType();
+      loadInterval(ar);
+      loadOutputFileName(ar);
+      atomTypeCoeffs_.allocate(nAtomType_);
+      loadDArray<double>(ar, "atomTypeCoeffs", atomTypeCoeffs_, nAtomType_);
+      loadParameter<int>(ar, "nBuffer", nBuffer_);
+      loadParameter<int>(ar, "nWave", nWave_);
+      waveIntVectors_.allocate(nWave_);
+      loadDArray<IntVector>(ar, "waveIntVectors", waveIntVectors_, nWave_);
+
+      // Load and broadcast nSample_
+      MpiLoader<Serializable::IArchive> loader(*this, ar);
+      loader.load(nSample_);
+      
+      if (simulation().domain().isMaster()) {
+         accumulators_.allocate(nWave_);
+         ar >> accumulators_;
+      }
+             
+      waveVectors_.allocate(nWave_);
+      fourierModes_.allocate(nWave_);
+      totalFourierModes_.allocate(nWave_);
+
+      isInitialized_ = true;
+   }
+
+   /*
+   * Save state to an archive.
+   */
+   void VanHove::save(Serializable::OArchive& ar)
+   { 
+      saveInterval(ar);
+      saveOutputFileName(ar);
+      ar << atomTypeCoeffs_;
+      ar << nBuffer_;
+      ar << nWave_;
+      ar << waveIntVectors_;
+
+      ar << nSample_;
+
+      if (simulation().domain().isMaster()) {
+         ar << accumulators_;
+      }
+   }
+
+   /*
+   * Clear accumulators.
+   */
+   void VanHove::clear() 
+   {
+      if (!isInitialized_) {
+         UTIL_THROW("Error: Object not initialized");
+      }
+      assert (nBuffer_ > 0);
+      assert (nWave_ > 0);
+      nSample_ = 0;
+      if (simulation().domain().isMaster()) {
+         for (int i = 0; i < nWave_; ++i) {
+            accumulators_[i].clear();
+         }
+      }
+   }
+ 
+   /// Increment Structure Factor
+   void VanHove::sample(long iStep) 
+   {
+      if (isAtInterval(iStep))  {
+
+         Vector  position;
+         std::complex<double>  expFactor;
+         double  product, coeff;
+         AtomIterator  atomIter;
+         int  i, j, typeId;
+
+         makeWaveVectors();
+
+         // Set all Fourier modes to zero
+         for (i = 0; i < nWave_; ++i) {
+            fourierModes_[i] = std::complex<double>(0.0, 0.0);
+         }
+ 
+         simulation().atomStorage().begin(atomIter);
+         for ( ; atomIter.notEnd(); ++atomIter) {
+            position = atomIter->position();
+            typeId   = atomIter->typeId();
+            coeff    = atomTypeCoeffs_[typeId];
+            
+            // Loop over wavevectors
+            for (i = 0; i < nWave_; ++i) {
+
+               product = position.dot(waveVectors_[i]);
+               expFactor = exp( product*Constants::Im );
+               fourierModes_[i] += coeff*expFactor;
+            }
+         }
+  
+         for (i = 0; i < nWave_; ++i) {
+            totalFourierModes_[i] = std::complex<double>(0.0, 0.0);
+         }
+
+         #ifdef UTIL_MPI
+         // Loop over wavevectors
+         for (int i = 0; i < nWave_; ++i) {
+            //Sum values from all processors.
+            simulation().domain().communicator().
+            Reduce(&fourierModes_[i], &totalFourierModes_[i],
+                    1, MPI::DOUBLE_COMPLEX, MPI::SUM, 0);
+         }
+         #else
+         for (int i = 0; i < nWave_; ++i) {
+            totalFourierModes_[i] = fourierModes_[i];
+         }
+         #endif
+         
+         if (simulation().domain().isMaster()) {
+            // Add Fourier modes to autocorrelation accumulators
+            double sqrtV = sqrt(simulation().boundary().volume());
+            for (int i = 0; i < nWave_; ++i) {
+               accumulators_[i].sample(totalFourierModes_[i]/sqrtV);
+            }
+         }
+         ++nSample_;
+      }
+
+   }
+
+   /**
+   * Calculate floating point wavevectors.
+   */
+   void VanHove::makeWaveVectors() 
+   {
+      Vector    dWave;
+      Boundary* boundaryPtr = &simulation().boundary();
+      int       i, j;
+
+      // Calculate wavevectors
+      for (i = 0; i < nWave_; ++i) {
+         waveVectors_[i] = Vector::Zero;
+         for (j = 0; j < Dimension; ++j) {
+            dWave  = boundaryPtr->reciprocalBasisVector(j);
+            dWave *= waveIntVectors_[i][j];
+            waveVectors_[i] += dWave;
+         }
+      }
+   }
+
+   void VanHove::output() 
+   {
+      if (simulation().domain().isMaster()) {
+         // Write parameters to a *.prm file
+         simulation().fileMaster().openOutputFile(outputFileName(".prm"),
+                                                  outputFile_);
+         writeParam(outputFile_);
+         outputFile_.close();
+        
+         // Output structure factors to one *.dat file
+         simulation().fileMaster().openOutputFile(outputFileName(".dat"),                                                                                         outputFile_);
+        
+         int i, j;
+
+         // Output autocorrelation functions to file
+         for (i = 0; i < nWave_; ++i) {
+
+            for (j = 0; j < Dimension; ++j) {
+               outputFile_ << Int(waveIntVectors_[i][j], 5);
+            }
+            outputFile_ << Dbl(waveVectors_[i].abs(), 20, 8);
+            outputFile_ << std::endl;
+            accumulators_[i].output(outputFile_);
+            outputFile_ << std::endl;
+            outputFile_ << std::endl;
+         }
+         outputFile_.close();
+      }
+
+   }
+
+}
+#endif

--- a/src/ddMd/analyzers/VanHove.h
+++ b/src/ddMd/analyzers/VanHove.h
@@ -1,0 +1,182 @@
+#ifndef DDMD_VAN_HOVE_H
+#define DDMD_VAN_HOVE_H
+
+/*
+* Simpatico - Simulation Package for Polymeric and Molecular Liquids
+*
+* Copyright 2010 - 2012, David Morse (morse012@umn.edu)
+* Distributed under the terms of the GNU General Public License.
+*/
+#include <ddMd/analyzers/Analyzer.h>
+#include <ddMd/simulation/Simulation.h>
+#include <util/containers/DArray.h>             // member template
+#include <util/containers/DMatrix.h>            // member template
+#include <util/accumulators/AutoCorr.h>         // member template parameter
+#include <util/space/Vector.h>                  // member template parameter
+
+#include <util/global.h>
+
+#include <iostream>
+#include <complex>
+
+namespace DdMd
+{
+
+   using namespace Util;
+
+   /**
+   * Evaluates the van Hove function S(k,t) for one or more wavevector k.
+   *
+   * The van Hove function S(k,t) is defined here as an expectation value
+   * \f[
+   *     S(k,t)  = < \psi(k,t) \psi^{*}(k,0) > / V
+   * \f]
+   * where V is system volume, and \f$\psi(k,t)\f$ is given by a sum
+   * \f[
+   *     \psi(k,t) = \sum_{i} c_{a} \exp( i k \cdot r_i )
+   * \f]
+   * over all atoms in the system, where \f$ c_{a} \f$ is a user-specified 
+   * coefficient for monomers of type a. 
+   *
+   * The Van Hove class can calculate S(k,t) for a list of wavevectors.
+   * Each wavevector is specified as an IntVector containing integer 
+   * Miller indices. These are the coefficients in an expansion of a 
+   * reciprocal lattice wavevector in terms of recprocal lattice basis 
+   * vectors.
+   *
+   * In a system with nAtomType = 2, with two monomer types 0 and 1,
+   * the parameter file input for calculating the autocorrelation of
+   * an order parameter \f$ \psi = \rho_0 - \rho_1 \f$ for 5 wavevectors 
+   * along the x axis in an orthorhombic unit cell might look like 
+   * this:
+   *
+   * \code
+   * VanHove{
+   *    interval                      1000
+   *    outputFileName             VanHove
+   *    atomTypeCoeffs              1.0000      -1.0000
+   *    nBuffer                        100
+   *    nWave                            5
+   *    waveIntVectors     8      0      0
+   *                       9      0      0 
+   *                      10      0      0 
+   *                      11      0      0 
+   *                      12      0      0 
+   * }
+   * \endcode
+   * At the end of a simulation, all of the autocorrelation functions 
+   * are output in a file with a suffix *.dat. Each line in this file
+   * contains the 3 Miller indices of a wavevector, the absolute
+   * magnitude of the wavevector, and a list of nAtomTypeIdPair structure 
+   * factor values for the wavevector, one for each atomTypeId pair.
+   * 
+   * \ingroup McMd_Analyzer_Module
+   */
+   class VanHove : public Analyzer
+   {
+   public:
+
+      /**	
+      * Constructor.
+      *
+      * \param system reference to parent System object
+      */
+      VanHove(Simulation &simulation);
+
+      /**	
+      * Destructor.
+      */
+      ~VanHove();
+
+      /**
+      * Read parameters from file.
+      *
+      * Input format:
+      *
+      *   - int               interval        sampling interval 
+      *   - string            outputFileName  output file base name
+      *   - DArray<double>    atomTypeCoeffs  array of type coefficients
+      *   - int               nBuffer         number of samples in buffer
+      *   - int               nWave           number of wavevectors
+      *   - DArray<IntVector> waveIntVectors  IntVector wavevectors
+      *
+      * \param in input parameter stream
+      */
+      virtual void readParameters(std::istream& in);
+
+      /**
+      * Load state from an archive.
+      *
+      * \param ar loading (input) archive.
+      */
+      virtual void loadParameters(Serializable::IArchive& ar);
+
+      /**
+      * Save state to an archive.
+      *
+      * \param ar saving (output) archive.
+      */
+      virtual void save(Serializable::OArchive& ar);
+  
+      /** 
+      * Clear accumulators.
+      */
+      virtual void clear();
+   
+      /**
+      * Add particle pairs to VanHove histogram.
+      *
+      * \param iStep step counter
+      */
+      void sample(long iStep);
+
+      /**
+      * Output results to predefined output file.
+      */
+      virtual void output();
+
+   protected:
+
+      /// Output file stream.
+      std::ofstream outputFile_;
+
+      /// Autocorrelation function accumulators.
+      DArray< AutoCorr< std::complex<double>, std::complex<double> >  >
+              accumulators_;
+
+      /// Fourier modes. First index is wavevector, second is atom type.
+      DArray< std::complex<double> >  fourierModes_;
+
+      DArray< std::complex<double> >  totalFourierModes_;
+
+      /// Array of miller index vectors for wavevectors
+      DArray<IntVector>  waveIntVectors_;
+
+      /// Array of wave vectors.
+      DArray<Vector>  waveVectors_;
+
+      /// Array of coefficients for atom types.
+      DArray<double>  atomTypeCoeffs_;
+
+      /// Number of wavevectors.
+      int  nWave_;
+
+      /// Number of samples stored in history buffer.
+      int  nBuffer_;
+
+      /// Number of samples thus far.
+      int  nSample_;
+
+      /// Number of atom types, copied from Simulation::nAtomType().
+      int  nAtomType_;
+
+      /// Has readParam been called?
+      bool isInitialized_;
+
+      /// Update wavevectors.
+      void makeWaveVectors();
+
+   };
+
+}
+#endif

--- a/src/ddMd/analyzers/sources.mk
+++ b/src/ddMd/analyzers/sources.mk
@@ -10,6 +10,7 @@ ddMd_analyzers_=\
      ddMd/analyzers/OutputPairEnergies.cpp\
      ddMd/analyzers/StructureFactor.cpp\
      ddMd/analyzers/StructureFactorGrid.cpp\
+     ddMd/analyzers/VanHove.cpp\
      ddMd/analyzers/OrderParamNucleation.cpp
 
 ddMd_analyzers_SRCS=\

--- a/src/ddMd/potentials/external/ExternalPotentialImpl.h
+++ b/src/ddMd/potentials/external/ExternalPotentialImpl.h
@@ -67,6 +67,10 @@ namespace DdMd
       */
       virtual void readParameters(std::istream& in);
 
+      virtual void loadParameters(Serializable::IArchive &ar);
+
+      virtual void save(Serializable::OArchive &ar);
+
       /// \name Interaction interface
       //@{
 
@@ -218,7 +222,25 @@ namespace DdMd
       addParamComposite(interaction(), nextIndent);
       interaction().readParameters(in);
    }
-  
+
+   /*
+   * Load internal state from an archive.
+   */
+   template <class Interaction>
+   void ExternalPotentialImpl<Interaction>::loadParameters(Serializable::IArchive &ar)
+   {
+      bool nextIndent = false;
+      addParamComposite(interaction(), nextIndent);
+      interaction().loadParameters(ar);
+   }
+
+   /*
+   * Save internal state to an archive.
+   */
+   template <class Interaction>
+   void ExternalPotentialImpl<Interaction>::save(Serializable::OArchive &ar)
+   {  interaction().save(ar); }
+ 
    /**
    * Set the maximum number of atom types.
    */

--- a/src/ddMd/simulation/Simulation.cpp
+++ b/src/ddMd/simulation/Simulation.cpp
@@ -2155,6 +2155,11 @@ namespace DdMd
          dihedralPotential().isValid(domain_.communicator());
       }
       #endif
+      #ifdef INTER_EXTERNAL
+      if (hasExternal_) {
+         externalPotential().isValid(domain_.communicator());
+      }
+      #endif
       #endif // ifdef UTIL_MPI
 
       return true;

--- a/src/ddMd/simulation/Simulation.h
+++ b/src/ddMd/simulation/Simulation.h
@@ -368,6 +368,24 @@ namespace DdMd
       * \return total pair energies (only correct on master node).
       */
       DMatrix<double> pairEnergies() const;
+     
+      #ifdef INTER_EXTERNAL
+      /**
+      * Compute pair energies for each pair of atom types.
+      * 
+      * Reduce operation: Must be called on all nodes.
+      */
+      void computeExternalEnergy();
+
+      /**
+      * Return precomputed pair energies.
+      *
+      * Call only on master processor, after computePairEnergies.
+      * 
+      * \return total pair energies (only correct on master node).
+      */
+      double externalEnergy() const;
+      #endif
 
       /**
       * Calculate and store kinetic stress.

--- a/src/inter/external/PeriodicExternal.cpp
+++ b/src/inter/external/PeriodicExternal.cpp
@@ -136,6 +136,39 @@ namespace Inter
       isInitialized_ = true;
    }
 
+   /*
+   * Load internal state from an archive.
+   */
+   void PeriodicExternal::loadParameters(Serializable::IArchive &ar)
+   {
+      ar >> nAtomType_;
+      if (nAtomType_ <= 0) {
+         UTIL_THROW( "nAtomType must be positive");
+      }
+      prefactor_.allocate(nAtomType_);
+      loadDArray<double>(ar, "prefactor", prefactor_, nAtomType_);
+      loadParameter<double>(ar, "externalParameter", externalParameter_);
+      waveIntVectors_.allocate(nWaveVectors_);
+      loadDArray<IntVector>(ar, "waveIntVectors", waveIntVectors_, nWaveVectors_);
+      loadParameter<double>(ar, "interfaceWidth", interfaceWidth_);
+      loadParameter<int>(ar, "periodicity", periodicity_);
+      isInitialized_ = true;
+   }
+
+   /*
+   * Save internal state to an archive.
+   */
+   void PeriodicExternal::save(Serializable::OArchive &ar)
+   {
+      ar << nAtomType_;
+      ar << prefactor_;
+      ar << externalParameter_;
+      ar << waveIntVectors_;
+      ar << interfaceWidth_;
+      ar << periodicity_;
+   }
+
+
    double PeriodicExternal::externalParameter() const
    { 
      return externalParameter_; 

--- a/src/inter/external/PeriodicExternal.h
+++ b/src/inter/external/PeriodicExternal.h
@@ -86,6 +86,20 @@ namespace Inter
       void readParameters(std::istream &in);
 
       /**
+      * Load internal state from an archive.
+      *
+      * \param ar input/loading archive
+      */
+      virtual void loadParameters(Serializable::IArchive &ar);
+
+      /**
+      * Save internal state to an archive.
+      *
+      * \param ar output/saving archive
+      */
+      virtual void save(Serializable::OArchive &ar);
+
+      /**
       * Returns external parameter
       *
       * \return external parameter
@@ -159,12 +173,12 @@ namespace Inter
       const Vector cellLengths = boundaryPtr_->lengths();
       double clipParameter = 1.0/(2.0*M_PI*periodicity_*interfaceWidth_);
 
-      Vector q;
       double cosine = 0.0;
       for (int i = 0; i < nWaveVectors_; ++i) {
-         q[0] = 2.0*M_PI*waveIntVectors_[i][0]/cellLengths[0];
-         q[1] = 2.0*M_PI*waveIntVectors_[i][1]/cellLengths[1]; 
-         q[2] = 2.0*M_PI*waveIntVectors_[i][2]/cellLengths[2];
+         Vector q;
+         q[0] = 2.0*M_PI*periodicity_*waveIntVectors_[i][0]/cellLengths[0];
+         q[1] = 2.0*M_PI*periodicity_*waveIntVectors_[i][1]/cellLengths[1]; 
+         q[2] = 2.0*M_PI*periodicity_*waveIntVectors_[i][2]/cellLengths[2];
          double arg = q.dot(position);
          cosine += cos(arg);
       }
@@ -184,12 +198,12 @@ namespace Inter
 
       double cosine = 0.0;
       Vector deriv;
-      Vector q;
       deriv.zero();
       for (int i = 0; i < nWaveVectors_; ++i) {
-         q[0] = 2.0*M_PI*waveIntVectors_[i][0]/cellLengths[0];
-         q[1] = 2.0*M_PI*waveIntVectors_[i][1]/cellLengths[1]; 
-         q[2] = 2.0*M_PI*waveIntVectors_[i][2]/cellLengths[2];
+         Vector q;
+         q[0] = 2.0*M_PI*periodicity_*waveIntVectors_[i][0]/cellLengths[0];
+         q[1] = 2.0*M_PI*periodicity_*waveIntVectors_[i][1]/cellLengths[1]; 
+         q[2] = 2.0*M_PI*periodicity_*waveIntVectors_[i][2]/cellLengths[2];
          double arg = q.dot(position);
          cosine += cos(arg);
          double sine = -1.0*sin(arg);


### PR DESCRIPTION
1. VanHove analyzer added in ddMd/analyzers
2. Potential energy in OutputEnergy now includes external energy if INTER_EXTERNAL is on
3. StructureFactor and StructureFactorGrid in ddMd/analyzers now output data at regular intervals through the simulation run
4. Addition of INTER_EXTERNAL methods- computeExternalEnergy() and externalEnergy() in ddMd/Simulation.cpp
5. loadParameters() and saveParameters() methods added to ddMd/potential/external/ExternalPotentialImpl.h
6. Similar changes in inter/extenal/PeriodicExternal.h
