### PR TITLE
Distributor and Collector objects moved to Storage

### DIFF
--- a/src/ddMd/communicate/AtomDistributor.cpp
+++ b/src/ddMd/communicate/AtomDistributor.cpp
@@ -68,7 +68,7 @@ namespace DdMd
    /*
    * Set cache capacity and allocate all required memory.
    */
-   void AtomDistributor::initialize(int cacheCapacity)
+   void AtomDistributor::allocate(int cacheCapacity)
    {
       cacheCapacity_ = cacheCapacity;
       allocate();

--- a/src/ddMd/communicate/AtomDistributor.h
+++ b/src/ddMd/communicate/AtomDistributor.h
@@ -115,7 +115,7 @@ namespace DdMd
       *
       * \param cacheCapacity max number of atoms cached for sending
       */
-      void initialize(int cacheCapacity = 100);
+      void allocate(int cacheCapacity);
 
       /**
       * Read cacheCapacity, allocate memory and initialize object.

--- a/src/ddMd/communicate/GroupCollector.tpp
+++ b/src/ddMd/communicate/GroupCollector.tpp
@@ -270,17 +270,5 @@ namespace DdMd
    }
    #endif
 
-   #ifdef INTER_BOND
-   template class GroupCollector<2>;
-   #endif
-
-   #ifdef INTER_ANGLE
-   template class GroupCollector<3>;
-   #endif
-
-   #ifdef INTER_DIHEDRAL
-   template class GroupCollector<4>;
-   #endif
-
 }
 #endif // ifndef DDMD_GROUP_COLLECTOR_TPP

--- a/src/ddMd/communicate/GroupDistributor.h
+++ b/src/ddMd/communicate/GroupDistributor.h
@@ -124,7 +124,7 @@ namespace DdMd
       *
       * \param cacheCapacity max number of groups cached for sending
       */
-      void initialize(int cacheCapacity = -1);
+      void allocate(int cacheCapacity);
 
       /**
       * Read cacheCapacity, allocate memory and initialize object.

--- a/src/ddMd/communicate/GroupDistributor.tpp
+++ b/src/ddMd/communicate/GroupDistributor.tpp
@@ -64,7 +64,7 @@ namespace DdMd
    * Set cache capacity and allocate all required memory.
    */
    template <int N>
-   void GroupDistributor<N>::initialize(int cacheCapacity)
+   void GroupDistributor<N>::allocate(int cacheCapacity)
    {
       cacheCapacity_ = cacheCapacity;
       allocate();
@@ -350,16 +350,5 @@ namespace DdMd
    }
    #endif
 
-   #ifdef INTER_BOND
-   template class GroupDistributor<2>;
-   #endif
-
-   #ifdef INTER_ANGLE
-   template class GroupDistributor<3>;
-   #endif
-
-   #ifdef INTER_DIHEDRAL
-   template class GroupDistributor<4>;
-   #endif
 }
 #endif

--- a/src/ddMd/configIos/ConfigIo.cpp
+++ b/src/ddMd/configIos/ConfigIo.cpp
@@ -47,25 +47,15 @@ namespace DdMd
    ConfigIo::ConfigIo()
     : domainPtr_(0),
       boundaryPtr_(0),
-      atomStoragePtr_(0),
+      atomStoragePtr_(0)
       #ifdef INTER_BOND
-      bondStoragePtr_(0),
+      , bondStoragePtr_(0)
       #endif
       #ifdef INTER_ANGLE
-      angleStoragePtr_(0),
+      , angleStoragePtr_(0)
       #endif
       #ifdef INTER_DIHEDRAL
-      dihedralStoragePtr_(0),
-      #endif
-      atomCacheCapacity_(0)
-      #ifdef INTER_BOND
-      , bondCacheCapacity_(0)
-      #endif
-      #ifdef INTER_ANGLE
-      , angleCacheCapacity_(0)
-      #endif
-      #ifdef INTER_DIHEDRAL
-      , dihedralCacheCapacity_(0)
+      , dihedralStoragePtr_(0)
       #endif
    {  setClassName("ConfigIo"); }
 
@@ -75,25 +65,15 @@ namespace DdMd
    ConfigIo::ConfigIo(Simulation& simulation)
     : domainPtr_(0),
       boundaryPtr_(0),
-      atomStoragePtr_(0),
+      atomStoragePtr_(0)
       #ifdef INTER_BOND
-      bondStoragePtr_(0),
+      , bondStoragePtr_(0)
       #endif
       #ifdef INTER_ANGLE
-      angleStoragePtr_(0),
+      , angleStoragePtr_(0)
       #endif
       #ifdef INTER_DIHEDRAL
-      dihedralStoragePtr_(0),
-      #endif
-      atomCacheCapacity_(0)
-      #ifdef INTER_BOND
-      , bondCacheCapacity_(0)
-      #endif
-      #ifdef INTER_ANGLE
-      , angleCacheCapacity_(0)
-      #endif
-      #ifdef INTER_DIHEDRAL
-      , dihedralCacheCapacity_(0)
+      , dihedralStoragePtr_(0)
       #endif
    {
       setClassName("ConfigIo"); 
@@ -152,86 +132,6 @@ namespace DdMd
 
    }
 
-   /*
-   * Set parameters and allocate memory.
-   */
-   void ConfigIo::initialize(int atomCacheCapacity
-                             #ifdef INTER_BOND
-                             , int bondCacheCapacity
-                             #endif
-                             #ifdef INTER_ANGLE
-                             , int angleCacheCapacity
-                             #endif
-                             #ifdef INTER_DIHEDRAL
-                             , int dihedralCacheCapacity
-                             #endif
-                            )
-   {
-      atomCacheCapacity_ = atomCacheCapacity;
-      #ifdef INTER_BOND
-      bondCacheCapacity_ = bondCacheCapacity;
-      #endif
-      #ifdef INTER_ANGLE
-      angleCacheCapacity_ = angleCacheCapacity;
-      #endif
-      #ifdef INTER_DIHEDRAL
-      dihedralCacheCapacity_ = dihedralCacheCapacity;
-      #endif
-   }
-
-   /*
-   * Read cache capacity parameters and allocate memory.
-   */
-   void ConfigIo::readParameters(std::istream& in)
-   {
-      read<int>(in, "atomCacheCapacity", atomCacheCapacity_);
-      #ifdef INTER_BOND
-      read<int>(in, "bondCacheCapacity", bondCacheCapacity_);
-      #endif
-      #ifdef INTER_ANGLE
-      read<int>(in, "angleCacheCapacity", angleCacheCapacity_);
-      #endif
-      #ifdef INTER_DIHEDRAL
-      read<int>(in, "dihedralCacheCapacity", dihedralCacheCapacity_);
-      #endif
-   }
-
-   /*
-   * Load internal state from input archive and allocate memory.
-   */
-   void ConfigIo::load(Serializable::IArchive& ar)
-   {
-      MpiLoader<Serializable::IArchive> loader(*this, ar);
-
-      loader.load(atomCacheCapacity_);
-
-      #ifdef INTER_BOND
-      loader.load(bondCacheCapacity_);
-      #endif
-      #ifdef INTER_ANGLE
-      loader.load(angleCacheCapacity_);
-      #endif
-      #ifdef INTER_DIHEDRAL
-      loader.load(dihedralCacheCapacity_);
-      #endif
-   }
-
-   /*
-   * Save internal state to output archive.
-   */
-   void ConfigIo::save(Serializable::OArchive& ar)
-   {
-      ar & atomCacheCapacity_;
-      #ifdef INTER_BOND
-      ar & bondCacheCapacity_;
-      #endif
-      #ifdef INTER_ANGLE
-      ar & angleCacheCapacity_;
-      #endif
-      #ifdef INTER_DIHEDRAL
-      ar & dihedralCacheCapacity_;
-      #endif
-   } 
 
    /*
    * Private method to read Group<N> objects.

--- a/src/ddMd/configIos/ConfigIo.h
+++ b/src/ddMd/configIos/ConfigIo.h
@@ -75,44 +75,6 @@ namespace DdMd
                      #endif
                      Buffer& buffer);
 
-      /**
-      * Set cache sizes and allocate memory.
-      *
-      * \param atomCacheCapacity size of internal atom cache. 
-      * \param bondCacheCapacity size of internal bond cache. 
-      * \param angleCacheCapacity size of internal angle cache. 
-      * \param dihedralCacheCapacity size of internal dihedral cache. 
-      */
-      virtual void initialize(int atomCacheCapacity = 100
-                              #ifdef INTER_BOND
-                              , int bondCacheCapacity = 100
-                              #endif
-                              #ifdef INTER_ANGLE
-                              , int angleCacheCapacity = 100
-                              #endif
-                              #ifdef INTER_DIHEDRAL                             
-                              , int dihedralCacheCapacity = 100
-                              #endif
-                              );
-
-      /**
-      * Read cache size and allocate memory.
-      */
-      virtual void readParameters(std::istream& in);
-
-      /**
-      * Load internal state of configIo (not configuration) from an archive.
-      *
-      * \param ar input/loading archive
-      */
-      virtual void load(Serializable::IArchive &ar);
-
-      /**
-      * Save internal state of ConfigIo (not configuration) to an archive.
-      *
-      * \param ar output/saving archive
-      */
-      virtual void save(Serializable::OArchive &ar);
 
       /**
       * Read a configuration file.
@@ -285,18 +247,6 @@ namespace DdMd
       DihedralStorage* dihedralStoragePtr_;
       #endif
 
-      // Cache capacities
-      int  atomCacheCapacity_;
-      #ifdef INTER_BOND
-      int  bondCacheCapacity_;
-      #endif
-      #ifdef INTER_ANGLE
-      int  angleCacheCapacity_;
-      #endif
-      #ifdef INTER_DIHEDRAL
-      int  dihedralCacheCapacity_;
-      #endif
-
       /**
       * Read Group<N> objects from file. 
       */
@@ -327,10 +277,10 @@ namespace DdMd
    {  return *atomStoragePtr_; }
 
    inline AtomDistributor& ConfigIo::atomDistributor()
-   {  return atomStoragePtr_->atomDistributor(); }
+   {  return atomStoragePtr_->distributor(); }
 
    inline AtomCollector& ConfigIo::atomCollector()
-   {  return atomStoragePtr_->atomCollector(); }
+   {  return atomStoragePtr_->collector(); }
 
    #ifdef INTER_BOND
    inline BondStorage& ConfigIo::bondStorage()

--- a/src/ddMd/potentials/pair/PairPotential.cpp
+++ b/src/ddMd/potentials/pair/PairPotential.cpp
@@ -107,6 +107,7 @@ namespace DdMd
    {
   
       loadParameter<double>(ar, "skin", skin_);
+      loadParameter<int>(ar, "nCellCut", nCellCut_, false);
       loadParameter<int>(ar, "pairCapacity", pairCapacity_);
       loadParameter<Boundary>(ar, "maxBoundary", maxBoundary_);
 
@@ -122,6 +123,7 @@ namespace DdMd
    void PairPotential::save(Serializable::OArchive& ar)
    {
       ar << skin_;
+      Parameter::saveOptional(ar, nCellCut_, true);
       ar << pairCapacity_;
       ar << maxBoundary_;
       ar << cutoff_;

--- a/src/ddMd/simulation/Simulation.cpp
+++ b/src/ddMd/simulation/Simulation.cpp
@@ -462,30 +462,30 @@ namespace DdMd
       readPotentialStyles(in);
 
       // Now that the domain and buffer have been initialized the Distributor
-      // and Collector objects can be associated and initialized
-      atomStorage_.atomDistributor().associate(domain_, boundary_, atomStorage_, buffer_);
-      atomStorage_.atomCollector().associate(domain_, atomStorage_, buffer_);
-      atomStorage_.atomDistributor().initialize(100);
-      atomStorage_.atomCollector().allocate(100);
+      // and Collector objects can be associated and allocated
+      atomStorage_.distributor().associate(domain_, boundary_, atomStorage_, buffer_);
+      atomStorage_.collector().associate(domain_, atomStorage_, buffer_);
+      atomStorage_.distributor().allocate(100);
+      atomStorage_.collector().allocate(100);
 
       #ifdef INTER_BOND
       bondStorage_.distributor().associate(domain_, atomStorage_, bondStorage_, buffer_);
       bondStorage_.collector().associate(domain_, bondStorage_, buffer_);
-      bondStorage_.distributor().initialize(100);
+      bondStorage_.distributor().allocate(100);
       bondStorage_.collector().allocate(100);
       #endif
 
       #ifdef INTER_ANGLE
       angleStorage_.distributor().associate(domain_, atomStorage_, angleStorage_, buffer_);
       angleStorage_.collector().associate(domain_, angleStorage_, buffer_);
-      angleStorage_.distributor().initialize(100);
+      angleStorage_.distributor().allocate(100);
       angleStorage_.collector().allocate(100);
       #endif
 
       #ifdef INTER_DIHEDRAL
       dihedralStorage_.distributor().associate(domain_, atomStorage_, dihedralStorage_, buffer_);
       dihedralStorage_.collector().associate(domain_, dihedralStorage_, buffer_);
-      dihedralStorage_.distributor().initialize(100);
+      dihedralStorage_.distributor().allocate(100);
       dihedralStorage_.collector().allocate(100);
       #endif
 
@@ -683,6 +683,34 @@ namespace DdMd
 
       // Load potentials styles and parameters
       loadPotentialStyles(ar);
+
+      // Now that the domain and buffer have been initialized the Distributor
+      // and Collector objects can be associated and allocated
+      atomStorage_.distributor().associate(domain_, boundary_, atomStorage_, buffer_);
+      atomStorage_.collector().associate(domain_, atomStorage_, buffer_);
+      atomStorage_.distributor().allocate(100);
+      atomStorage_.collector().allocate(100);
+
+      #ifdef INTER_BOND
+      bondStorage_.distributor().associate(domain_, atomStorage_, bondStorage_, buffer_);
+      bondStorage_.collector().associate(domain_, bondStorage_, buffer_);
+      bondStorage_.distributor().allocate(100);
+      bondStorage_.collector().allocate(100);
+      #endif
+
+      #ifdef INTER_ANGLE
+      angleStorage_.distributor().associate(domain_, atomStorage_, angleStorage_, buffer_);
+      angleStorage_.collector().associate(domain_, angleStorage_, buffer_);
+      angleStorage_.distributor().allocate(100);
+      angleStorage_.collector().allocate(100);
+      #endif
+
+      #ifdef INTER_DIHEDRAL
+      dihedralStorage_.distributor().associate(domain_, atomStorage_, dihedralStorage_, buffer_);
+      dihedralStorage_.collector().associate(domain_, dihedralStorage_, buffer_);
+      dihedralStorage_.distributor().allocate(100);
+      dihedralStorage_.collector().allocate(100);
+      #endif
 
       #ifndef DDMD_NOPAIR
       // Pair Potential
@@ -1920,7 +1948,6 @@ namespace DdMd
    {
       if (configIoPtr_ == 0) {
          configIoPtr_ = new DdMdConfigIo(*this);
-         configIoPtr_->initialize();
       }
       return *configIoPtr_;
    }
@@ -1932,7 +1959,6 @@ namespace DdMd
    {
       if (serializeConfigIoPtr_ == 0) {
          serializeConfigIoPtr_ = new SerializeConfigIo(*this);
-         serializeConfigIoPtr_->initialize();
       }
       return *serializeConfigIoPtr_;
    }
@@ -2111,7 +2137,6 @@ namespace DdMd
          delete configIoPtr_;
       }
       configIoPtr_ = ptr;
-      configIoPtr_->initialize();
    }
 
    // --- Validation ---------------------------------------------------

--- a/src/ddMd/sp/chemistry/SpMolecule.h
+++ b/src/ddMd/sp/chemistry/SpMolecule.h
@@ -81,7 +81,7 @@ namespace DdMd
    inline SpSpecies& SpMolecule::species() const
    {
       assert(speciesPtr_);
-      assert(id < nAtom_);
+      assert(id_ < nAtom_);
       return *speciesPtr_;
    }
 

--- a/src/ddMd/storage/AtomStorage.h
+++ b/src/ddMd/storage/AtomStorage.h
@@ -405,12 +405,12 @@ namespace DdMd
       /**
       * Get the AtomDistributor by reference.
       */
-      AtomDistributor& atomDistributor();
+      AtomDistributor& distributor();
 
       /**
       * Get the AtomCollector by reference.
       */
-      AtomCollector& atomCollector();
+      AtomCollector& collector();
 
       #endif
    
@@ -546,8 +546,8 @@ namespace DdMd
       Setable<int>  maxNGhost_;     
 
       // Distributors and collectors
-      AtomDistributor atomDistributor_;
-      AtomCollector atomCollector_;
+      AtomDistributor distributor_;
+      AtomCollector collector_;
 
       #endif
 
@@ -578,11 +578,11 @@ namespace DdMd
    { return ghostSet_.size(); }
 
    #ifdef UTIL_MPI
-   inline AtomDistributor& AtomStorage::atomDistributor()
-   {  return atomDistributor_; }
+   inline AtomDistributor& AtomStorage::distributor()
+   {  return distributor_; }
 
-   inline AtomCollector& AtomStorage::atomCollector()
-   {  return atomCollector_; }
+   inline AtomCollector& AtomStorage::collector()
+   {  return collector_; }
    #endif
 
    inline int AtomStorage::atomCapacity() const

--- a/src/ddMd/storage/GroupStorage.tpp
+++ b/src/ddMd/storage/GroupStorage.tpp
@@ -12,6 +12,8 @@
 #include "AtomStorage.h"
 #include <util/format/Int.h>
 #include <util/mpi/MpiLoader.h>  
+#include <ddMd/communicate/GroupDistributor.tpp>   // member
+#include <ddMd/communicate/GroupCollector.tpp>     // member
 
 //#define DDMD_GROUP_STORAGE_DEBUG
 


### PR DESCRIPTION
Restructured code so the (Atom|Group)(Distributor|Collector) objects are
now members of the (Atom|Group)Storage classes instead of the configIo
class.  This required doing the associating/initializing/allocating of
these objects only once inside the simulation class.  As a result of
this, specifying the parameters (atom|bond|angle|dihedral)CacheCapacity
inside the parameter file will no longer do anything.  These parameters
have all been hardcoded to 100.
