### PR TITLE
Modified makefiles for Parallel Compilation

### DIFF
--- a/bld/serial/modules/sliplink/makefile
+++ b/bld/serial/modules/sliplink/makefile
@@ -33,11 +33,11 @@ MDSIM_EXE=$(BIN_DIR)/mdSim$(BIN_SUFFIX)
 # Major targets
 
 all:	
-	make $(modules_sliplink_OBJS)
-	make $(MDSIM).o
-	make $(MCSIM).o
-	make $(MDSIM_EXE) 
-	make $(MCSIM_EXE) 
+	$(MAKE) $(modules_sliplink_OBJS)
+	$(MAKE) $(MDSIM).o
+	$(MAKE) $(MCSIM).o
+	$(MAKE) $(MDSIM_EXE) 
+	$(MAKE) $(MCSIM_EXE) 
 
 clean:
 	-rm $(MCSIM_EXE) mcSim.o mcSim.d

--- a/makefile
+++ b/makefile
@@ -9,29 +9,29 @@ include src/config.mk
 # Main build targets
 
 all:
-	cd bld/serial; make mcMd
-	cd bld/parallel; make ddMd
-	cd bld/parallel; make mcMd-mpi
+	cd bld/serial; $(MAKE) mcMd
+	cd bld/parallel; $(MAKE) ddMd
+	cd bld/parallel; $(MAKE) mcMd-mpi
 
 # Build serial mcSim and mdSim MC and MD programs in bld/serial
 mcMd:
-	cd bld/serial; make mcMd
+	cd bld/serial; $(MAKE) mcMd
 
 # Build embarassingly parallel mcSim and mdSim programs in bld/parallel
 mcMd-mpi: 
-	cd bld/parallel; make mcMd-mpi
+	cd bld/parallel; $(MAKE) mcMd-mpi
 
 # Build parallel mdSim MD program in bld/parallel
 ddMd:
-	cd bld/parallel; make ddMd
+	cd bld/parallel; $(MAKE) ddMd
 
 # ==============================================================================
 # Test targets
 
 test-serial:
-	@cd bld/serial/util/tests; make all; make run
-	@cd bld/serial/inter/tests; make all; make run
-	@cd bld/serial/mcMd/tests; make all; make run
+	@cd bld/serial/util/tests; $(MAKE) all; $(MAKE) run
+	@cd bld/serial/inter/tests; $(MAKE) all; $(MAKE) run
+	@cd bld/serial/mcMd/tests; $(MAKE) all; $(MAKE) run
 	@cat bld/serial/util/tests/count > count
 	@cat bld/serial/inter/tests/count >> count
 	@cat bld/serial/mcMd/tests/count >> count
@@ -39,7 +39,7 @@ test-serial:
 	@rm -f count
 
 test-parallel:
-	cd bld/parallel/ddMd/tests; make all; make run
+	cd bld/parallel/ddMd/tests; $(MAKE) all; $(MAKE) run
 	@cat bld/parallel/ddMd/tests/count >> count
 	@cat count
 	@rm -f count
@@ -49,15 +49,15 @@ test-parallel:
 # Clean targets
 
 clean-serial:
-	cd bld/serial; make clean
+	cd bld/serial; $(MAKE) clean
 
 clean-parallel:
-	cd bld/parallel; make clean
+	cd bld/parallel; $(MAKE) clean
 
 clean:
-	cd src; make clean
-	cd bld/serial; make clean
-	cd bld/parallel; make clean
+	cd src; $(MAKE) clean
+	cd bld/serial; $(MAKE) clean
+	cd bld/parallel; $(MAKE) clean
 
 clean-bin:
 	-rm -f $(BIN_DIR)/mcSim*
@@ -65,21 +65,21 @@ clean-bin:
 	-rm -f $(BIN_DIR)/ddSim*
  
 veryclean:
-	cd bld/serial; make veryclean; rm -f makefile configure
+	cd bld/serial; $(MAKE) veryclean; rm -f makefile configure
 	cd bld/serial; rm -f util/makefile inter/makefile mcMd/makefile ddMd/makefile 
-	cd bld/parallel; make veryclean; rm -f makefile configure
+	cd bld/parallel; $(MAKE) veryclean; rm -f makefile configure
 	cd bld/parallel; rm -f util/makefile inter/makefile mcMd/makefile ddMd/makefile 
-	cd doc; make clean
-	make clean-bin
-	cd src; make veryclean
+	cd doc; $(MAKE) clean
+	$(MAKE) clean-bin
+	cd src; $(MAKE) veryclean
 
 # =========================================================================
 # HTML Documentation
  
 html:
-	cd doc; make html
+	cd doc; $(MAKE) html
 
 clean-html:
-	cd doc; make clean
+	cd doc; $(MAKE) clean
 
 # ==============================================================================

--- a/src/ddMd/makefile
+++ b/src/ddMd/makefile
@@ -34,24 +34,24 @@ $(DDSIM_EXE): $(DDSIM).o $(LIBS)
 	$(CXX) $(LDFLAGS) -o $(DDSIM_EXE) $(DDSIM).o $(LIBS)
 
 ddSim:
-	make $(DDSIM_EXE)
+	$(MAKE) $(DDSIM_EXE)
 
 $(MDPP_EXE): $(MDPP).o $(LIBS)
 	$(CXX) $(LDFLAGS) -o $(MDPP_EXE) $(MDPP).o $(LIBS)
 
 mdPp:
-	make $(MDPP_EXE)
+	$(MAKE) $(MDPP_EXE)
 
 clean:
 	rm -f $(ddMd_OBJS) $(ddMd_OBJS:.o=.d) $(ddMd_LIB)
 	rm -f $(DDSIM).o $(DDSIM).d
 	rm -f $(MDPP).o $(MDPP).d
-	cd tests; make clean
+	cd tests; $(MAKE) clean
 	rm -f *.o */*.o */*/*.o
 	rm -f *.d */*.d */*/*.d
 
 veryclean:
-	make clean
+	$(MAKE) clean
 	rm -f lib*.a
 ifeq ($(BLD_DIR),$(SRC_DIR))
 	rm -f configIos/ConfigIoFactory.cpp

--- a/src/ddMd/tests/makefile
+++ b/src/ddMd/tests/makefile
@@ -22,19 +22,19 @@ run: $(ddMd_tests_OBJS) $(BLD_DIR)/$(TEST)
 clean:
 	rm -f $(ddMd_tests_OBJS) $(ddMd_tests_OBJS:.o=.d)
 	rm -f $(BLD_DIR)/$(TEST)
-	cd chemistry; make clean
-	cd communicate; make clean
-	cd configIos; make clean
-	cd neighbor; make clean
-	cd potentials; make clean
-	cd simulation; make clean
-	cd storage; make clean
-	make clean-outputs
+	cd chemistry; $(MAKE) clean
+	cd communicate; $(MAKE) clean
+	cd configIos; $(MAKE) clean
+	cd neighbor; $(MAKE) clean
+	cd potentials; $(MAKE) clean
+	cd simulation; $(MAKE) clean
+	cd storage; $(MAKE) clean
+	$(MAKE) clean-outputs
 
 clean-outputs:
 	rm -f log count
-	cd chemistry; make clean-outputs
-	cd configIos; make clean-outputs
+	cd chemistry; $(MAKE) clean-outputs
+	cd configIos; $(MAKE) clean-outputs
         
 -include $(ddMd_tests_OBJS:.o=.d)
 -include $(ddMd_OBJS:.o=.d)

--- a/src/ddMd/tests/sp/makefile
+++ b/src/ddMd/tests/sp/makefile
@@ -16,10 +16,10 @@ run:
 	cd configIos; ./Test
 
 clean:
-	cd chemistry; make clean
-	cd storage; make clean
-	cd configIos; make clean
-	cd processor; make clean
+	cd chemistry; $(MAKE) clean
+	cd storage; $(MAKE) clean
+	cd configIos; $(MAKE) clean
+	cd processor; $(MAKE) clean
 	rm -f Test Test.d Test.o
 
 -include $(ddMd_tests_sp_OBJS:.o=.d)

--- a/src/inter/makefile
+++ b/src/inter/makefile
@@ -20,10 +20,10 @@ all: $(inter_OBJS) $(inter_LIB)
 
 clean:
 	rm -f $(inter_OBJS) $(inter_OBJS:.o=.d) $(inter_LIB)
-	cd tests; make clean
+	cd tests; $(MAKE) clean
 
 veryclean:
-	make clean
+	$(MAKE) clean
 	rm -f */*.o */*.d
 	rm -f lib*.a
 

--- a/src/inter/tests/makefile
+++ b/src/inter/tests/makefile
@@ -20,10 +20,10 @@ run: $(inter_tests_OBJS)
 clean:
 	rm -f $(inter_tests_OBJS) $(inter_tests_OBJS:.o=.d) $(BLD_DIR)/$(TEST)
 	rm -f log count
-	cd pair; make clean
-	cd bond; make clean
-	cd angle; make clean
-	cd dihedral; make clean
+	cd pair; $(MAKE) clean
+	cd bond; $(MAKE) clean
+	cd angle; $(MAKE) clean
+	cd dihedral; $(MAKE) clean
 
 $(BLD_DIR)/$(TEST): $(BLD_DIR)/$(TEST).o $(LIBS)
 

--- a/src/inter/tests/pair/makefile
+++ b/src/inter/tests/pair/makefile
@@ -13,7 +13,7 @@ clean:
 	rm -f $(inter_tests_pair_OBJS)
 	rm -f $(inter_tests_pair_OBJS:.o=.d)
 	rm -f $(inter_tests_pair_OBJS:.o=)
-	make clean-outputs
+	$(MAKE) clean-outputs
 
 clean-outputs:
 	rm -f out/*

--- a/src/makefile
+++ b/src/makefile
@@ -4,37 +4,37 @@
 # Serial versions of mdSim and mcSim MD and MC programs (MPI disabled)
 mcMd: 
 	./configure -m0
-	cd util; make all
-	cd inter; make all
-	cd mcMd; make all
+	cd util; $(MAKE) all
+	cd inter; $(MAKE) all
+	cd mcMd; $(MAKE) all
 
 # Embarassingly parallel mdSim and mcSim MD and MC programs (MPI enabled)
 mcMd-mpi: 
 	./configure -m1
-	cd util; make all
-	cd inter; make all
-	cd mcMd; make all
+	cd util; $(MAKE) all
+	cd inter; $(MAKE) all
+	cd mcMd; $(MAKE) all
  
 # Domain-decomposition ddSim molecular dynamics program (MPI enabled)
 ddMd:
 	./configure -m1
-	cd util; make all
-	cd inter; make all
-	cd ddMd; make all
+	cd util; $(MAKE) all
+	cd inter; $(MAKE) all
+	cd ddMd; $(MAKE) all
 
 # Remove object (*.o), dependency (*.d) and library (*.a) files
 clean:
-	cd util; make clean
-	cd inter; make clean
-	cd mcMd; make clean
-	cd ddMd; make clean
+	cd util; $(MAKE) clean
+	cd inter; $(MAKE) clean
+	cd mcMd; $(MAKE) clean
+	cd ddMd; $(MAKE) clean
 
 # Remove all automatically generated files, return to as-distributed state
 veryclean:
-	cd util; make veryclean
-	cd inter; make veryclean
-	cd mcMd; make veryclean
-	cd ddMd; make veryclean
+	cd util; $(MAKE) veryclean
+	cd inter; $(MAKE) veryclean
+	cd mcMd; $(MAKE) veryclean
+	cd ddMd; $(MAKE) veryclean
 	rm -f util/config.mk
 	rm -f inter/config.mk
 	rm -f mcMd/config.mk

--- a/src/mcMd/makefile
+++ b/src/mcMd/makefile
@@ -32,12 +32,12 @@ clean:
 	rm -f $(mcMd_OBJS) $(mcMd_OBJS:.o=.d) $(mcMd_LIB)
 	rm -f $(MDSIM).o $(MDSIM).d
 	rm -f $(MCSIM).o $(MCSIM).d
-	cd tests; make clean
+	cd tests; $(MAKE) clean
 	rm -f *.o */*.o */*/*.o
 	rm -f *.d */*.d */*/*.d
 
 veryclean:
-	make clean
+	$(MAKE) clean
 	rm -f lib*.a
 ifeq ($(BLD_DIR),$(SRC_DIR))
 	rm -f configIos/ConfigIoFactory.cpp
@@ -68,10 +68,10 @@ $(MDSIM_EXE): $(MDSIM).o $(LIBS)
 # Short names for executable targets (for convenience)
  
 mcSim:
-	make $(MCSIM_EXE)
+	$(MAKE) $(MCSIM_EXE)
 
 mdSim:
-	make $(MDSIM_EXE)
+	$(MAKE) $(MDSIM_EXE)
 
 #-----------------------------------------------------------------------
 # Include dependency files

--- a/src/mcMd/tests/chemistry/makefile
+++ b/src/mcMd/tests/chemistry/makefile
@@ -21,7 +21,7 @@ clean:
 	rm -f $(mcMd_tests_chemistry_OBJS)
 	rm -f $(mcMd_tests_chemistry_OBJS:.o=.d)
 	rm -f $(mcMd_tests_chemistry_OBJS:.o=)
-	make clean-outputs
+	$(MAKE) clean-outputs
 
 clean-outputs:
 	rm -f ar.txt binary

--- a/src/mcMd/tests/makefile
+++ b/src/mcMd/tests/makefile
@@ -24,13 +24,13 @@ clean:
 	rm -f $(mcMd_tests_OBJS:.o=.d)
 	rm -f $(mcMd_tests_OBJS:.o=)
 	rm -f *.cfg log count
-	cd chemistry; make clean
-	cd mcSimulation; make clean
-	cd mdSimulation; make clean
-	cd mdIntegrators; make clean
-	cd neighbor; make clean
-	cd simulation; make clean
-	cd species; make clean
+	cd chemistry; $(MAKE) clean
+	cd mcSimulation; $(MAKE) clean
+	cd mdSimulation; $(MAKE) clean
+	cd mdIntegrators; $(MAKE) clean
+	cd neighbor; $(MAKE) clean
+	cd simulation; $(MAKE) clean
+	cd species; $(MAKE) clean
 
 -include $(mcMd_tests_OBJS:.o=.d)
 -include $(mcMd_OBJS:.o=.d)

--- a/src/mcMd/tests/mcSimulation/makefile
+++ b/src/mcMd/tests/mcSimulation/makefile
@@ -17,7 +17,7 @@ clean:
 	rm -f $(mcMd_tests_mcSimulation_OBJS) 
 	rm -f $(mcMd_tests_mcSimulation_OBJS:.o=.d)
 	rm -f $(mcMd_tests_mcSimulation_OBJS:.o=)
-	make clean-outputs
+	$(MAKE) clean-outputs
 
 clean-outputs:
 	rm -f out/param

--- a/src/mcMd/tests/mdSimulation/makefile
+++ b/src/mcMd/tests/mdSimulation/makefile
@@ -17,7 +17,7 @@ clean:
 	rm -f $(mcMd_tests_mdSimulation_OBJS) 
 	rm -f $(mcMd_tests_mdSimulation_OBJS:.o=.d)
 	rm -f $(mcMd_tests_mdSimulation_OBJS:.o=)
-	make clean-outputs
+	$(MAKE) clean-outputs
 
 clean-outputs:
 	rm -f *.rst *.cfg

--- a/src/modules/sliplink/makefile
+++ b/src/modules/sliplink/makefile
@@ -33,11 +33,11 @@ MDSIM_EXE=$(BIN_DIR)/mdSim$(BIN_SUFFIX)
 # Major targets
 
 all:	
-	make $(modules_sliplink_OBJS)
-	make $(MDSIM).o
-	make $(MCSIM).o
-	make $(MDSIM_EXE) 
-	make $(MCSIM_EXE) 
+	$(MAKE) $(modules_sliplink_OBJS)
+	$(MAKE) $(MDSIM).o
+	$(MAKE) $(MCSIM).o
+	$(MAKE) $(MDSIM_EXE) 
+	$(MAKE) $(MCSIM_EXE) 
 
 clean:
 	-rm -f $(MCSIM_EXE) mcSim.o mcSim.d

--- a/src/util/makefile
+++ b/src/util/makefile
@@ -19,10 +19,10 @@ all: $(util_OBJS) $(util_LIB)
 
 clean:
 	rm -f $(util_OBJS) $(util_OBJS:.o=.d) $(util_LIB)
-	cd tests; make clean
+	cd tests; $(MAKE) clean
 
 veryclean:
-	make clean
+	$(MAKE) clean
 	rm -f */*.o */*/*.o */*/*/*.o
 	rm -f */*.d */*/*.d */*/*/*.d
 	rm -f lib*.a

--- a/src/util/tests/accumulators/makefile
+++ b/src/util/tests/accumulators/makefile
@@ -1,6 +1,6 @@
 all:
-	cd stochastic; make all
-	cd unit; make all
+	cd stochastic; $(MAKE) all
+	cd unit; $(MAKE) all
 clean:
-	cd stochastic; make clean
-	cd unit; make clean
+	cd stochastic; $(MAKE) clean
+	cd unit; $(MAKE) clean

--- a/src/util/tests/accumulators/stochastic/makefile
+++ b/src/util/tests/accumulators/stochastic/makefile
@@ -9,18 +9,18 @@ include $(SRC_DIR)/util/sources.mk
 include sources.mk
 
 all: $(tests_util_accumulators_stochastic_OBJS)
-	cd autocorr; make all
-	cd average;  make all
-	cd averageStage; make all
-	cd meanSqDisp; make all
-	cd random; make all
+	cd autocorr; $(MAKE) all
+	cd average;  $(MAKE) all
+	cd averageStage; $(MAKE) all
+	cd meanSqDisp; $(MAKE) all
+	cd random; $(MAKE) all
 
 clean:
-	cd autocorr; make clean
-	cd average;  make clean
-	cd averageStage; make clean
-	cd meanSqDisp; make clean
-	cd random; make clean
+	cd autocorr; $(MAKE) clean
+	cd average;  $(MAKE) clean
+	cd averageStage; $(MAKE) clean
+	cd meanSqDisp; $(MAKE) clean
+	cd random; $(MAKE) clean
 	rm -f $(tests_util_accumulators_stochastic_OBJS) $(tests_util_accumulators_stochastic_OBJS:.o=.d)
 
 clean-deps:

--- a/src/util/tests/accumulators/unit/makefile
+++ b/src/util/tests/accumulators/unit/makefile
@@ -12,7 +12,7 @@ all: $(util_tests_accumulators_unit_OBJS) $(TEST)
 clean:
 	rm -f $(util_tests_accumulators_unit_OBJS) $(util_tests_accumulators_unit_OBJS:.o=.d)
 	rm -f $(TEST) 
-	make clean-outputs
+	$(MAKE) clean-outputs
 
 clean-outputs:
 	rm -f binary

--- a/src/util/tests/archives/makefile
+++ b/src/util/tests/archives/makefile
@@ -12,7 +12,7 @@ all: $(util_tests_archives_OBJS) $(BLD_DIR)/$(TEST)
 clean:
 	rm -f $(util_tests_archives_OBJS) $(util_tests_archives_OBJS:.o=.d)
 	rm -f $(BLD_DIR)/$(TEST) 
-	make clean-outputs
+	$(MAKE) clean-outputs
 
 clean-outputs:
 	rm -f dummy text binary

--- a/src/util/tests/containers/makefile
+++ b/src/util/tests/containers/makefile
@@ -12,7 +12,7 @@ all: $(util_tests_containers_OBJS) $(BLD_DIR)/$(TEST)
 clean:
 	rm -f $(util_tests_containers_OBJS) $(util_tests_containers_OBJS:.o=.d)
 	rm -f $(BLD_DIR)/$(TEST)
-	make clean-outputs
+	$(MAKE) clean-outputs
 
 clean-outputs:
 	rm -f binary

--- a/src/util/tests/makefile
+++ b/src/util/tests/makefile
@@ -19,17 +19,17 @@ clean:
 	rm -f $(util_tests_OBJS) $(util_tests_OBJS:.o=.d)
 	rm -f $(BLD_DIR)/$(TEST) $(BLD_DIR)/$(TEST).d
 	rm -f dummy log count
-	cd accumulators/unit; make clean
-	cd archives; make clean
-	cd boundary; make clean
-	cd containers; make clean
-	cd crystal; make clean
-	cd format; make clean
-	cd misc; make clean
-	cd param; make clean
-	cd random; make clean
-	cd signal; make clean
-	cd space; make clean
+	cd accumulators/unit; $(MAKE) clean
+	cd archives; $(MAKE) clean
+	cd boundary; $(MAKE) clean
+	cd containers; $(MAKE) clean
+	cd crystal; $(MAKE) clean
+	cd format; $(MAKE) clean
+	cd misc; $(MAKE) clean
+	cd param; $(MAKE) clean
+	cd random; $(MAKE) clean
+	cd signal; $(MAKE) clean
+	cd space; $(MAKE) clean
 	rm -f */*.o */*/*.o 
 	rm -f */*.d */*/*.d
 

--- a/src/util/tests/param/makefile
+++ b/src/util/tests/param/makefile
@@ -1,3 +1,3 @@
 clean:
-	cd mpi; make clean
-	cd serial; make clean
+	cd mpi; $(MAKE) clean
+	cd serial; $(MAKE) clean

--- a/src/util/tests/param/serial/makefile
+++ b/src/util/tests/param/serial/makefile
@@ -11,7 +11,7 @@ clean:
 	rm -f $(util_tests_param_serial_OBJS) 
 	rm -f $(util_tests_param_serial_OBJS:.o=.d)
 	rm -f $(util_tests_param_serial_OBJS:.o=)
-	make clean-outputs
+	$(MAKE) clean-outputs
 
 clean-outputs:
 	rm -f out/*

--- a/src/util/tests/random/makefile
+++ b/src/util/tests/random/makefile
@@ -12,7 +12,7 @@ all: $(util_tests_random_OBJS) $(BLD_DIR)/$(TEST)
 clean:
 	rm -f $(util_tests_random_OBJS) $(util_tests_random_OBJS:.o=.d)
 	rm -f $(BLD_DIR)/$(TEST) 
-	make clean-outputs
+	$(MAKE) clean-outputs
 
 clean-outputs:
 	rm -f binary

--- a/tools/cpp/hoomd/makefile
+++ b/tools/cpp/hoomd/makefile
@@ -19,7 +19,7 @@ EXTRACT_TOPOLOGY_EXE=$(BIN_DIR)/extract_topology$(BIN_SUFFIX)
 #-----------------------------------------------------------------------
 
 all:
-	make $(EXTRACT_TOPOLOGY_EXE) 
+	$(MAKE) $(EXTRACT_TOPOLOGY_EXE) 
 
 clean:	
 	rm -f $(EXTRACT_TOPOLOGY_EXE) 

--- a/tools/cpp/makefile
+++ b/tools/cpp/makefile
@@ -2,9 +2,9 @@
 .PHONY: clean 
 
 clean: 
-	cd atomicMaker;  make clean
-	cd chainMaker; make clean
-	cd rings; make clean
-	cd hoomd; make clean
+	cd atomicMaker;  $(MAKE) clean
+	cd chainMaker; $(MAKE) clean
+	cd rings; $(MAKE) clean
+	cd hoomd; $(MAKE) clean
 
 # ==============================================================================

--- a/tools/makefile
+++ b/tools/makefile
@@ -2,7 +2,7 @@
 .PHONY: clean 
 
 clean: 
-	cd cpp;  make clean
-	#cd python; make clean
+	cd cpp;  $(MAKE) clean
+	#cd python; $(MAKE) clean
 
 # ==============================================================================


### PR DESCRIPTION
The makefiles have been modified to use the $(MAKE) variable instead of
the word make.  This allows the '-j N' flag to be passed to make which
tells it to spawn N processes and build in parallel. The following is
taken from the GNU make manual:

In order for make processes to communicate, the parent will pass
information to the child. Since this could result in problems if the
child process isn't actually a make, the parent will only do this if it
thinks the child is a make.
see http://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html
