### PR TITLE
Added the ability to comment lines with a pound sign

### DIFF
--- a/src/util/misc/ioUtil.cpp
+++ b/src/util/misc/ioUtil.cpp
@@ -13,13 +13,14 @@ namespace Util
 {
 
    /*
-   * Strip trailing whitespace from a string.
+   * Strip trailing whitespace and comments from a string.
    */
    int rStrip(std::string& str)
    {
-      size_t found;
-      std::string whitespaces(" \t\n\r");
-      found = str.find_last_not_of(whitespaces);
+      size_t found, cindx;
+      std::string whitespaces(" \t\n\r#");
+      cindx = str.find_first_of("#");
+      found = str.find_last_not_of(whitespaces, cindx);
       if (found != std::string::npos) {
         str.erase(found + 1);
         return int(found + 1);

--- a/src/util/tests/misc/in/getNextLine
+++ b/src/util/tests/misc/in/getNextLine
@@ -1,3 +1,4 @@
    
+#  I'll just throw a comment here
    This is the first line   
    

--- a/src/util/tests/misc/ioUtilTest.h
+++ b/src/util/tests/misc/ioUtilTest.h
@@ -26,7 +26,7 @@ public:
    void tearDown()
    {};
 
-   void testRStrip() 
+   void testRStrip1() 
    {
       printMethod(TEST_FUNC);
 
@@ -35,6 +35,22 @@ public:
       int len = rStrip(full);
       TEST_ASSERT(len == 22);
       TEST_ASSERT(full == lean);
+   }
+
+   void testRStrip2()
+   {
+      printMethod(TEST_FUNC);
+
+      std::string full("  important stuff # comment about important stuff");
+      std::string lean("  important stuff");
+      int len = rStrip(full);
+      TEST_ASSERT(len == 17);
+      TEST_ASSERT(full == lean);
+
+      full = "# this is totally a comment line";
+      len = rStrip(full);
+      TEST_ASSERT(len == 0);
+      TEST_ASSERT(full.empty());
    }
 
    /*
@@ -149,7 +165,8 @@ public:
 };
 
 TEST_BEGIN(ioUtilTest)
-TEST_ADD(ioUtilTest, testRStrip)
+TEST_ADD(ioUtilTest, testRStrip1)
+TEST_ADD(ioUtilTest, testRStrip2)
 TEST_ADD(ioUtilTest, testGetLine)
 TEST_ADD(ioUtilTest, testGetNextLine1)
 TEST_ADD(ioUtilTest, testGetNextLine2)


### PR DESCRIPTION
This is useful for debugging / developing because you can just copy lines
and change them slightly while commenting out the old lines rather than
having to delete them when you might need them later.  Another option we
could do is to only consider lines beginning with a pound to be comments.

The function getNextLine is only called by the various Simulation objects
to read commands / config files.  It is also called by HoomdConfigReader
and LammpsDumpReader but those two file formats do not use the pound sign
so this shouldn't cause any problems.  If we still do not want this to
affect the reading of those file formats  I could implement a different
getNextLine function used only when the simulation objects read their
configs.
